### PR TITLE
Added pagination trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A lightweight and extensible sitemap generator for Laravel that supports automat
 - 🧩 [Model dynamic route](docs/template.md) support via `->sitemapUsing(Model::class)` macro
 - 🔁 [Template dynamic route](docs/template.md) support via `->sitemapUsing(SitemapItemTemplate::class)` macro
 - 📦 [Dynamic route](docs/dynamic-routes.md) support via `->dynamic()` macro
+- 📄 [Easy sitemap entries for paginated resource listings](docs/sitemap-pagination.md) with the `HasPaginatedSitemap` trait
 - ✏️ Customize entries with `lastmod`, `priority`, `changefreq`
 - 🧼 Clean and compliant XML output
 - 💾 Store sitemaps to disk or serve via route
@@ -28,6 +29,20 @@ A lightweight and extensible sitemap generator for Laravel that supports automat
 - 🚀 Laravel 10, Laravel 11 and Laravel 12 support
   - `1.*` for Laravel 12.4
   - `2.*` for Laravel 10, 11 and 12
+
+---
+
+## 📚 Documentation
+
+For advanced usage see the documentation below.
+
+- [`docs/sitemap.md`](docs/sitemap.md)
+- [`docs/url.md`](docs/url.md)
+- [`docs/image.md`](docs/image.md)
+- [`docs/sitemap-pagination.md`](docs/sitemap-pagination.md)
+- [`docs/sitemapindex.md`](docs/sitemapindex.md)
+- [`docs/dynamic-routes.md`](docs/dynamic-routes.md)
+- [`docs/template.md`](docs/template.md)
 
 ---
 
@@ -214,17 +229,6 @@ vendor/bin/pest
 ```
 
 SQLite must be enabled for in-memory testing.
-
----
-
-## 📚 Documentation
-
-- [`docs/sitemap.md`](docs/sitemap.md)
-- [`docs/url.md`](docs/url.md)
-- [`docs/image.md`](docs/image.md)
-- [`docs/sitemapindex.md`](docs/sitemapindex.md)
-- [`docs/dynamic-routes.md`](docs/dynamic-routes.md)
-- [`docs/template.md`](docs/template.md)
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "veiliglanceren/laravel-seo-sitemap",
     "description": "Laravel Sitemap package to optimize your website in search engines",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "type": "library",
     "license": "MIT",
     "require": {

--- a/docs/sitemap-pagination.md
+++ b/docs/sitemap-pagination.md
@@ -1,0 +1,91 @@
+# Traits
+
+## `HasPaginatedSitemap`
+
+The `HasPaginatedSitemap` trait allows you to easily generate paginated URLs for resource index pages, such as blog or news listing pages, in your sitemap templates.
+
+This is particularly useful when you want to include URLs like `/blog?page=1`, `/blog?page=2`, etc., in your sitemap for paginated resource listings.
+
+---
+
+### Usage
+
+1. **Include the trait in your sitemap template class:**
+
+```php
+use VeiligLanceren\LaravelSeoSitemap\Support\Traits\HasPaginatedSitemap;
+
+class BlogIndexTemplate implements SitemapItemTemplate
+{
+    use HasPaginatedSitemap;
+
+    public function generate(Route $route): iterable
+    {
+        $totalItems = Post::published()->count();
+        $perPage = 20;
+
+        yield from $this->paginatedUrls($route, $totalItems, $perPage);
+    }
+}
+```
+
+2. **Method Signature**
+
+```php
+protected function paginatedUrls(
+    Route $route,
+    int $totalItems,
+    int $perPage = 20,
+    string $pageParam = 'page',
+    array $extraParams = [],
+    bool $skipPageOne = false
+): \Traversable
+```
+
+- **$route**: The current route instance.
+- **$totalItems**: The total number of items in your resource (e.g., total blog posts).
+- **$perPage**: The number of items displayed per page.
+- **$pageParam**: The query parameter used for pagination (default: `'page'`).
+- **$extraParams**: (Optional) Any additional route parameters to be merged.
+- **$skipPageOne**: (Optional) If set to `true`, the first page (`?page=1`) is not included in the generated URLs.
+
+---
+
+### Example: Skipping Page 1
+
+If your application routes `/blog` (without `?page=1`) to the first page, you may want to exclude the `?page=1` URL from the sitemap:
+
+```php
+yield from $this->paginatedUrls($route, $totalItems, $perPage, 'page', [], true);
+```
+
+---
+
+### Example: Using Extra Route Parameters
+
+If your paginated route requires extra parameters (e.g., category), provide them as an associative array:
+
+```php
+yield from $this->paginatedUrls($route, $totalItems, $perPage, 'page', ['category' => $category->slug]);
+```
+
+---
+
+### Output
+
+Each call to `paginatedUrls()` yields a `Url` object for each paginated page, which can be used directly in your sitemap template's `generate()` method.
+
+---
+
+### Notes
+
+- This trait is useful for efficiently generating sitemap entries for paginated listings.
+- For individual resource entries (e.g., `/blog/my-post`), use your own logic.
+- Ensure your route/controller supports the pagination query parameter.
+
+---
+
+## See also
+
+- [`SitemapItemTemplate` documentation](./template.md)
+- [Laravel Pagination Documentation](https://laravel.com/docs/pagination)

--- a/src/Sitemap/Item/Url.php
+++ b/src/Sitemap/Item/Url.php
@@ -157,4 +157,12 @@ class Url extends SitemapItem
 
         return $data;
     }
+
+    /**
+     * @return string
+     */
+    public function getLoc(): string
+    {
+        return $this->loc;
+    }
 }

--- a/src/Support/Traits/HasPaginatedSitemap.php
+++ b/src/Support/Traits/HasPaginatedSitemap.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace VeiligLanceren\LaravelSeoSitemap\Support\Traits;
+
+use Traversable;
+use Illuminate\Routing\Route;
+use VeiligLanceren\LaravelSeoSitemap\Sitemap\Item\Url;
+
+trait HasPaginatedSitemap
+{
+    /**
+     * Generate paginated URLs for a resource index.
+     *
+     * @param Route $route
+     * @param int $totalItems
+     * @param int $perPage
+     * @param string $pageParam
+     * @param array $extraParams Extra route parameters to merge in (optional)
+     * @param bool $skipPageOne If true, do not include ?page=1 (default: false)
+     * @return Traversable<Url>
+     */
+    protected function paginatedUrls(
+        Route $route,
+        int $totalItems,
+        int $perPage = 20,
+        string $pageParam = 'page',
+        array $extraParams = [],
+        bool $skipPageOne = false
+    ): Traversable {
+        $totalPages = (int) ceil($totalItems / $perPage);
+
+        for ($page = 1; $page <= $totalPages; $page++) {
+            if ($skipPageOne && $page === 1) {
+                continue;
+            }
+
+            $params = array_merge($extraParams, [$pageParam => $page]);
+
+            yield Url::make(route($route->getName(), $params));
+        }
+    }
+}

--- a/tests/Feature/MixedRoutesIntegrationTest.php
+++ b/tests/Feature/MixedRoutesIntegrationTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use VeiligLanceren\LaravelSeoSitemap\Sitemap\Sitemap;
+use Tests\Fixtures\SitemapTemplates\BlogPostTemplate;
 
 beforeEach(function () {
     Route::middleware([])->group(function () {
@@ -16,7 +17,7 @@ beforeEach(function () {
 
             Route::get('/{category}/{post}', fn () => 'blog post')
                 ->name('support.blog.show')
-                ->sitemapUsing(\Tests\Fixtures\SitemapTemplates\BlogPostTemplate::class);
+                ->sitemapUsing(BlogPostTemplate::class);
         });
     });
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,3 +1,5 @@
 <?php
 
-uses(Tests\TestCase::class)->in('Unit', 'Feature');
+use Tests\TestCase;
+
+uses(TestCase::class)->in('Unit', 'Feature');

--- a/tests/Support/Sitemap/ItemTemplate/DummySitemapTemplate.php
+++ b/tests/Support/Sitemap/ItemTemplate/DummySitemapTemplate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Support\Sitemap\ItemTemplate;
+
+use Illuminate\Routing\Route;
+use VeiligLanceren\LaravelSeoSitemap\Support\Traits\HasPaginatedSitemap;
+
+class DummySitemapTemplate
+{
+    use HasPaginatedSitemap;
+
+    /**
+     * @param Route $route
+     * @param int $total
+     * @param int $per
+     * @param array $extra
+     * @param bool $skipOne
+     * @return array
+     */
+    public function getUrls(Route $route, int $total, int $per = 2, array $extra = [], bool $skipOne = false): array
+    {
+        return iterator_to_array($this->paginatedUrls($route, $total, $per, 'page', $extra, $skipOne));
+    }
+}

--- a/tests/Support/Sitemap/ItemTemplate/DummyTemplate.php
+++ b/tests/Support/Sitemap/ItemTemplate/DummyTemplate.php
@@ -21,6 +21,9 @@ class DummyTemplate implements SitemapItemTemplate
         ];
     }
 
+    /**
+     * @return Traversable
+     */
     public function getIterator(): Traversable
     {
         yield from $this->generate(app(LaravelRoute::class));

--- a/tests/Unit/Support/Traits/HasPaginatedSitemapTest.php
+++ b/tests/Unit/Support/Traits/HasPaginatedSitemapTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Routing\Route;
+use Tests\Support\Sitemap\ItemTemplate\DummySitemapTemplate;
+
+beforeEach(function () {
+    app('router')
+        ->get('/dummy', function () {})
+        ->name('test.route');
+});
+
+function getRouteMock(): Route {
+    $route = Mockery::mock(Route::class)->makePartial();
+    $route->shouldReceive('getName')->andReturn('test.route');
+    return $route;
+}
+
+it('generates paginated urls', function () {
+    $template = new DummySitemapTemplate();
+    $route = getRouteMock();
+
+    $urls = $template->getUrls($route, 5, 2);
+
+    expect($urls)->toHaveCount(3)
+        ->and($urls[0]->getLoc())->toBe(url('/dummy?page=1'))
+        ->and($urls[1]->getLoc())->toBe(url('/dummy?page=2'))
+        ->and($urls[2]->getLoc())->toBe(url('/dummy?page=3'));
+});
+
+it('can skip page one', function () {
+    $template = new DummySitemapTemplate();
+    $route = getRouteMock();
+
+    $urls = $template->getUrls($route, 5, 2, [], true);
+
+    expect($urls)->toHaveCount(2)
+        ->and($urls[0]->getLoc())->toBe(url('/dummy?page=2'))
+        ->and($urls[1]->getLoc())->toBe(url('/dummy?page=3'));
+});
+
+it('merges additional params', function () {
+    $template = new DummySitemapTemplate();
+    $route = getRouteMock();
+
+    $urls = $template->getUrls($route, 2, 1, ['foo' => 'bar']);
+
+    expect($urls[0]->getLoc())->toBe(url('/dummy?foo=bar&page=1'));
+});


### PR DESCRIPTION
## Add HasPaginatedSitemap Trait for Paginated Sitemap URL Generation

### Overview

This PR introduces the `HasPaginatedSitemap` trait, making it easy to generate sitemap entries for paginated resource listings (such as `/blog?page=2`, `/products?page=5`, etc.) in your sitemap templates.

### Features

- Provides a reusable trait for generating paginated URLs based on a given route, total item count, and items per page.
- Supports additional route parameters and the option to skip the first page (`?page=1`).
- Integrates with existing sitemap templates for seamless paginated sitemap support.
- Includes documentation on how to use the trait in custom templates.
- Adds and updates tests to ensure correct URL output and edge case handling.

### Usage Example

```php
use VeiligLanceren\LaravelSeoSitemap\Support\Traits\HasPaginatedSitemap;

class BlogIndexTemplate implements SitemapItemTemplate
{
    use HasPaginatedSitemap;

    public function generate(Route $route): iterable
    {
        $totalItems = Post::published()->count();
        $perPage = 20;

        yield from $this->paginatedUrls($route, $totalItems, $perPage);
    }
}
```

### Documentation

- New documentation page added: `docs/sitemap-pagination.md`
- Feature listed in the main README under Features

### Motivation

Paginated resource listings are common in modern web applications. Including all relevant paginated URLs in the sitemap improves SEO and ensures search engines can index all content pages. This trait provides a simple and consistent way to handle this use case across multiple templates.
