### PR TITLE
Add route image macro for sitemap image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ php artisan sitemap:generate
 
 ---
 
-## `🖼` Add images to the sitemap 
+## `🖼` Add images to the sitemap
+
+### Using `Url` instances directly
 
 ```php
 use VeiligLanceren\LaravelSeoSitemap\Sitemap\Item\Url;
@@ -198,6 +200,14 @@ use VeiligLanceren\LaravelSeoSitemap\Sitemap\Item\Image;
 $url = Url::make('https://example.com')
     ->addImage(Image::make('https://example.com/image1.jpg')->title('Hero 1'))
     ->addImage(Image::make('https://example.com/image2.jpg')->title('Hero 2'));
+```
+
+### Via route macros
+
+```php
+Route::get('/about', AboutController::class)
+    ->name('about')
+    ->image('https://example.com/hero.jpg');
 ```
 
 ---

--- a/docs/image.md
+++ b/docs/image.md
@@ -23,6 +23,14 @@ $url = Url::make('https://example.com')
     ->addImage(Image::make('https://example.com/image2.jpg')->caption('Scene 2'));
 ```
 
+### Adding images via route macros
+
+```php
+Route::get('/about', AboutController::class)
+    ->name('about')
+    ->image('https://example.com/hero.jpg');
+```
+
 ---
 
 ## 🧾 XML Output

--- a/src/Macros/RouteImage.php
+++ b/src/Macros/RouteImage.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace VeiligLanceren\LaravelSeoSitemap\Macros;
+
+use Illuminate\Routing\Route as RoutingRoute;
+use VeiligLanceren\LaravelSeoSitemap\Popo\RouteSitemapDefaults;
+use VeiligLanceren\LaravelSeoSitemap\Sitemap\Item\Image;
+
+class RouteImage
+{
+    /**
+     * @return void
+     */
+    public static function register(): void
+    {
+        RoutingRoute::macro('image', function (string $url, ?string $title = null) {
+            /** @var RoutingRoute $this */
+            $existing = $this->defaults['sitemap'] ?? new RouteSitemapDefaults();
+
+            $existing->enabled = true;
+
+            $image = Image::make($url);
+
+            if ($title !== null) {
+                $image->title($title);
+            }
+
+            $existing->images[] = $image;
+
+            $this->defaults['sitemap'] = $existing;
+
+            return $this;
+        });
+    }
+}

--- a/src/Macros/RouteSitemap.php
+++ b/src/Macros/RouteSitemap.php
@@ -164,6 +164,12 @@ class RouteSitemap
             $url->index($defaults->index);
         }
 
+        if (!empty($defaults->images)) {
+            foreach ($defaults->images as $image) {
+                $url->addImage($image);
+            }
+        }
+
         return $url;
     }
 

--- a/src/Popo/RouteSitemapDefaults.php
+++ b/src/Popo/RouteSitemapDefaults.php
@@ -4,6 +4,7 @@ namespace VeiligLanceren\LaravelSeoSitemap\Popo;
 
 use Scrumble\Popo\BasePopo;
 use VeiligLanceren\LaravelSeoSitemap\Support\Enums\ChangeFrequency;
+use VeiligLanceren\LaravelSeoSitemap\Sitemap\Item\Image;
 
 class RouteSitemapDefaults extends BasePopo
 {
@@ -31,4 +32,9 @@ class RouteSitemapDefaults extends BasePopo
      * @var string|null
      */
     public ?string $index = null;
+
+    /**
+     * @var Image[]
+     */
+    public array $images = [];
 }

--- a/src/SitemapServiceProvider.php
+++ b/src/SitemapServiceProvider.php
@@ -9,6 +9,7 @@ use VeiligLanceren\LaravelSeoSitemap\Macros\RouteSitemap;
 use VeiligLanceren\LaravelSeoSitemap\Macros\RoutePriority;
 use VeiligLanceren\LaravelSeoSitemap\Macros\RouteChangefreq;
 use VeiligLanceren\LaravelSeoSitemap\Macros\RouteSitemapIndex;
+use VeiligLanceren\LaravelSeoSitemap\Macros\RouteImage;
 use VeiligLanceren\LaravelSeoSitemap\Services\SitemapService;
 use VeiligLanceren\LaravelSeoSitemap\Macros\RouteSitemapUsing;
 use VeiligLanceren\LaravelSeoSitemap\Console\Commands\InstallSitemap;
@@ -65,6 +66,7 @@ class SitemapServiceProvider extends ServiceProvider
         RoutePriority::register();
         RouteChangefreq::register();
         RouteDynamic::register();
+        RouteImage::register();
         RouteSitemapIndex::register();
     }
 }

--- a/tests/Unit/Macros/RouteImageMacroTest.php
+++ b/tests/Unit/Macros/RouteImageMacroTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use VeiligLanceren\LaravelSeoSitemap\Macros\RouteImage;
+use VeiligLanceren\LaravelSeoSitemap\Macros\RouteSitemap;
+use VeiligLanceren\LaravelSeoSitemap\Popo\RouteSitemapDefaults;
+use VeiligLanceren\LaravelSeoSitemap\Sitemap\Item\Url;
+use VeiligLanceren\LaravelSeoSitemap\Sitemap\Item\Image;
+
+beforeEach(function () {
+    RouteImage::register();
+    RouteSitemap::register();
+
+    Route::get('/test-image', fn () => 'ok')
+        ->name('test.image')
+        ->image('https://example.com/hero.jpg', 'Hero');
+});
+
+it('stores image instances on the route defaults', function () {
+    $route = Route::get('/default-image', fn () => 'ok')
+        ->name('default.image')
+        ->image('https://example.com/cover.jpg', 'Cover');
+
+    $defaults = $route->defaults['sitemap'];
+
+    expect($defaults)->toBeInstanceOf(RouteSitemapDefaults::class)
+        ->and($defaults->images)->toHaveCount(1)
+        ->and($defaults->images[0])->toBeInstanceOf(Image::class)
+        ->and($defaults->images[0]->toArray())->toBe([
+            'loc' => 'https://example.com/cover.jpg',
+            'title' => 'Cover',
+        ]);
+});
+
+it('propagates images to generated Url objects', function () {
+    $urls = RouteSitemap::urls();
+
+    expect($urls)->toHaveCount(1)
+        ->and($urls->first())->toBeInstanceOf(Url::class)
+        ->and($urls->first()->getImages())->toHaveCount(1)
+        ->and($urls->first()->getImages()[0]->toArray())->toBe([
+            'loc' => 'https://example.com/hero.jpg',
+            'title' => 'Hero',
+        ]);
+});


### PR DESCRIPTION
## Summary
- allow routes to declare images via new `->image()` macro
- attach declared images when generating sitemap URLs
- document and test image macro usage

## Testing
- `vendor/bin/pest`